### PR TITLE
Toggle search and filter visibility on posts page

### DIFF
--- a/src/app/_components/search-and-filters.tsx
+++ b/src/app/_components/search-and-filters.tsx
@@ -15,7 +15,12 @@ import {
 import { X, Search, Filter, SortAsc, SortDesc } from "lucide-react";
 import { useQueryState } from "nuqs";
 
-export function SearchAndFilters() {
+interface SearchAndFiltersProps {
+  showFilters: boolean;
+  onToggleFilters: () => void;
+}
+
+export function SearchAndFilters({ showFilters, onToggleFilters }: SearchAndFiltersProps) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
 
@@ -26,7 +31,6 @@ export function SearchAndFilters() {
   const [dateFrom, setDateFrom] = useQueryState("dateFrom");
   const [dateTo, setDateTo] = useQueryState("dateTo");
   const [limit, setLimit] = useQueryState("limit");
-  const [showFilters, setShowFilters] = useState(false);
 
   const updateURL = () => {
     const params = new URLSearchParams();
@@ -72,16 +76,6 @@ export function SearchAndFilters() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-1 sm:gap-2">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => setShowFilters(!showFilters)}
-            className="h-8 sm:h-7 px-2 sm:px-3 text-xs sm:text-sm"
-          >
-            <Filter className="h-3 w-3 sm:h-4 sm:w-4 mr-1" />
-            <span className="hidden sm:inline">{showFilters ? "Hide" : "Show"}</span>
-            <span className="sm:hidden">{showFilters ? "Hide Filters" : "Filters"}</span>
-          </Button>
           {hasActiveFilters && (
             <Button
               variant="ghost"

--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -1,8 +1,12 @@
+"use client";
+
 import Container from "@/app/_components/container";
 import { DynamicHomeContent } from "@/app/_components/dynamic-home-content";
 import { SearchAndFilters } from "../_components/search-and-filters";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, Filter } from "lucide-react";
 import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { useState, useEffect } from "react";
 
 export const experimental_ppr = true;
 
@@ -20,12 +24,23 @@ type Props = {
   searchParams: Promise<SearchParams>;
 };
 
-function Filters() {
-  return <SearchAndFilters />;
+function Filters({ showFilters, onToggleFilters }: { showFilters: boolean; onToggleFilters: () => void }) {
+  return <SearchAndFilters showFilters={showFilters} onToggleFilters={onToggleFilters} />;
 }
 
-export default async function Index({ searchParams }: Props) {
-  const params = await searchParams;
+export default function Index({ searchParams }: Props) {
+  const [showFilters, setShowFilters] = useState(false);
+  
+  const handleToggleFilters = () => {
+    setShowFilters(!showFilters);
+  };
+
+  // Handle async searchParams
+  const [resolvedParams, setResolvedParams] = useState<any>(null);
+  
+  useEffect(() => {
+    searchParams.then(setResolvedParams);
+  }, [searchParams]);
 
   return (
     <>
@@ -40,13 +55,22 @@ export default async function Index({ searchParams }: Props) {
                 <ArrowLeft className="w-4 h-4 mr-2 group-hover:-translate-x-1 transition-transform" />
                 Back to Home
               </Link>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleToggleFilters}
+                className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground transition-colors group mt-4 sm:mt-0"
+              >
+                <Filter className="w-4 h-4 mr-2 group-hover:scale-110 transition-transform" />
+                {showFilters ? "Hide Filters" : "Show Filters"}
+              </Button>
             </div>
             {/* Static content that renders immediately */}
             {/* <Intro /> */}
 
             {/* Dynamic content that streams in */}
-            <Filters />
-            <DynamicHomeContent searchParams={params} />
+            <Filters showFilters={showFilters} onToggleFilters={handleToggleFilters} />
+            {resolvedParams && <DynamicHomeContent searchParams={resolvedParams} />}
           </div>
         </Container>
       </div>


### PR DESCRIPTION
Move the search and filters toggle button to the posts page header to align with the "Back to Home" link, as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-3ea12252-2fc0-4968-9c52-d01d21973017"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3ea12252-2fc0-4968-9c52-d01d21973017"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

